### PR TITLE
fix(ci): stash, checkout, restore

### DIFF
--- a/.github/workflows/build-releases.yml
+++ b/.github/workflows/build-releases.yml
@@ -362,7 +362,7 @@ jobs:
         with:
           tag_name: ${{ needs.validate.outputs.tag_name }}
           target_commitish: ${{ needs.validate.outputs.branch_name }}
-          name: gdalcli for GDAL ${{ needs.validate.outputs.gdal_version }}
+          name: gdalcli v${{ needs.validate.outputs.package_version }} for GDAL ${{ needs.validate.outputs.gdal_version }}
           draft: false
           prerelease: false
           body: |


### PR DESCRIPTION
This pull request updates the build release workflow to ensure that any generated or uncommitted files are properly handled during the branch preparation process. 

* Added step to stash new untracked generated files, before fetching and preparing the release branch in `.github/workflows/build-releases.yml`.
* Added step to pop the stashed changes after switching to the target branch

Also, makes the release title have format `"gdalcli vX.Y.Z for GDAL A.B.C" for clarity at a glance on both versions