### PR TITLE
ci: add workflow for cleaning up GHCR images

### DIFF
--- a/.github/workflows/cleanup-ghcr.yml
+++ b/.github/workflows/cleanup-ghcr.yml
@@ -1,0 +1,69 @@
+---
+name: Cleanup GHCR Images
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run mode (show what would be removed without actually removing)'
+        required: false
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+      keep_versions:
+        description: 'Number of recent GDAL versions to keep (all images per version preserved)'
+        required: false
+        default: '3'
+        type: string
+      force:
+        description: 'Force removal without confirmation prompts'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+
+permissions:
+  packages: write
+
+jobs:
+  cleanup-ghcr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Authenticate with GitHub CLI
+        run: |
+          # Use GITHUB_TOKEN for authentication
+          gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Run GHCR cleanup script
+        run: |
+          ARGS="--owner brownag --repo gdalcli"
+          
+          # Add optional arguments
+          [ "${{ github.event.inputs.dry_run }}" != "false" ] && ARGS="$ARGS --dry-run"
+          [ -n "${{ github.event.inputs.keep_versions }}" ] && ARGS="$ARGS --keep ${{ github.event.inputs.keep_versions }}"
+          [ "${{ github.event.inputs.force }}" = "true" ] && ARGS="$ARGS --force"
+          
+          # Run the cleanup script
+          chmod +x ./scripts/cleanup-ghcr-images.sh
+          ./scripts/cleanup-ghcr-images.sh $ARGS
+
+      - name: Cleanup summary
+        if: always()
+        run: |
+          cat >> $GITHUB_STEP_SUMMARY <<'SUMMARY'
+          ## GHCR Cleanup Summary
+          
+          | Setting | Value |
+          |---------|-------|
+          | Dry Run | ${{ github.event.inputs.dry_run || 'true' }} |
+          | Keep Versions | ${{ github.event.inputs.keep_versions || '3' }} |
+          | Force Mode | ${{ github.event.inputs.force || 'false' }} |
+          | Status | ${{ job.status }} |
+          SUMMARY

--- a/scripts/cleanup-ghcr-images.sh
+++ b/scripts/cleanup-ghcr-images.sh
@@ -1,0 +1,317 @@
+#!/bin/bash
+
+# cleanup-ghcr-images.sh
+# GitHub CLI script to cleanup old Docker images from GHCR
+# Run this locally to clean up old images from GitHub Container Registry
+
+set -e
+
+# Configuration
+REPO_OWNER="brownag"
+REPO_NAME="gdalcli"
+KEEP_VERSIONS=3
+DRY_RUN=false
+FORCE=false
+
+usage() {
+    echo "Usage: $0 [--dry-run] [--force] [--keep VERSIONS] [--owner OWNER] [--repo REPO]"
+    echo "  --dry-run: Show what would be removed without actually removing"
+    echo "  --force: Skip confirmation prompts"
+    echo "  --keep VERSIONS: Number of recent GDAL versions to keep (default: $KEEP_VERSIONS)"
+    echo "                   All images for each kept GDAL version will be preserved"
+    echo "  --owner OWNER: Repository owner (default: $REPO_OWNER)"
+    echo "  --repo REPO: Repository name (default: $REPO_NAME)"
+    echo
+    echo "Requires GitHub CLI (gh) to be authenticated:"
+    echo "  gh auth login"
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --force)
+            FORCE=true
+            shift
+            ;;
+        --keep)
+            KEEP_VERSIONS="$2"
+            shift 2
+            ;;
+        --owner)
+            REPO_OWNER="$2"
+            shift 2
+            ;;
+        --repo)
+            REPO_NAME="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            ;;
+    esac
+done
+
+# Check if gh CLI is available and authenticated
+if ! command -v gh &> /dev/null; then
+    echo "[ERROR] GitHub CLI (gh) is not installed. Please install it first:"
+    echo "   https://cli.github.com/"
+    exit 1
+fi
+
+if ! gh auth status &> /dev/null; then
+    echo "[ERROR] GitHub CLI is not authenticated. Please run:"
+    echo "   gh auth login"
+    exit 1
+fi
+
+# Check if token has packages scope
+if ! gh auth token | gh api /user/packages?package_type=container &>/dev/null; then
+    echo "[ERROR] Your GitHub token doesn't have packages permissions."
+    echo "   Required scopes: read:packages (and write:packages for deletion)"
+    echo
+    echo "   Please re-authenticate with packages permissions:"
+    echo "   gh auth login --scopes read:packages,write:packages,repo"
+    echo
+    echo "   Or add scopes to existing authentication:"
+    echo "   gh auth refresh --scopes read:packages,write:packages"
+    exit 1
+fi
+
+echo "[ACTION] GHCR Cleanup Script"
+echo "Repository: $REPO_OWNER/$REPO_NAME"
+echo "Keep GDAL versions: $KEEP_VERSIONS (all images per version)"
+if [ "$DRY_RUN" = true ]; then
+    echo "Mode: DRY RUN (no changes will be made)"
+else
+    echo "Mode: LIVE RUN (images will be deleted)"
+fi
+echo
+
+# Get all container packages for this repository
+echo "[PKG] Fetching container packages..."
+echo "   Using user packages endpoint..."
+
+# Use user packages endpoint (packages are owned by the user, not org)
+packages=$(gh api "/user/packages?package_type=container" \
+    --jq ".[] | select(.repository.name == \"$REPO_NAME\") | .name" 2>&1)
+
+api_exit_code=$?
+if [ $api_exit_code -ne 0 ]; then
+    echo "   User packages endpoint failed (exit code: $api_exit_code): $packages"
+fi
+
+# Check if we got a valid response
+if [[ "$packages" == *"Not Found"* ]] || [[ "$packages" == *"403"* ]] || [[ "$packages" == *"404"* ]]; then
+    echo "[ERROR] API call failed: $packages"
+    echo "This might mean you don't have permission to access packages."
+    exit 1
+fi
+
+if [ -z "$packages" ] || [[ "$packages" == *"[]"* ]]; then
+    echo "No container packages found for $REPO_OWNER/$REPO_NAME"
+    echo "This might mean:"
+    echo "  - No Docker images have been built and pushed to GHCR yet"
+    echo "  - The images exist but you don't have permission to list them"
+    echo "  - The repository has no container packages"
+    echo
+    echo "To check if images exist, you can try:"
+    echo "  docker pull ghcr.io/$REPO_OWNER/$REPO_NAME:deps-gdal-3.11.4-amd64"
+    echo "  docker pull ghcr.io/$REPO_OWNER/$REPO_NAME:gdal-3.11.4-latest"
+    echo
+    echo "If images exist but this script can't find them, the issue might be with API permissions."
+    exit 0
+fi
+
+echo "Found packages:"
+echo "$packages" | sed 's/^/  - /'
+echo
+
+total_removed=0
+
+# Process each package
+while IFS= read -r package; do
+    if [ -z "$package" ]; then continue; fi
+
+    echo "[FIND] Processing package: $package"
+
+    # Get all versions for this package with their tags
+    echo "  Fetching version details..."
+    all_versions=$(gh api "/user/packages/container/$package/versions" \
+        --jq '.[] | {id: .id, created_at: .created_at, tags: (.metadata.container.tags // [])}')
+
+    # Parse versions and group by GDAL version
+    declare -A gdal_versions
+    declare -A version_details
+
+    while IFS= read -r version_json; do
+        if [ -z "$version_json" ]; then continue; fi
+
+        version_id=$(echo "$version_json" | jq -r '.id')
+        created_at=$(echo "$version_json" | jq -r '.created_at')
+        tags=$(echo "$version_json" | jq -r '.tags[]')
+
+        # Extract GDAL version from tags
+        gdal_ver=""
+        for tag in $tags; do
+            if [[ $tag =~ gdal-([0-9]+\.[0-9]+) ]]; then
+                gdal_ver="${BASH_REMATCH[1]}"
+                break
+            elif [[ $tag =~ deps-gdal-([0-9]+\.[0-9]+) ]]; then
+                gdal_ver="${BASH_REMATCH[1]}"
+                break
+            fi
+        done
+
+        # If no GDAL version found in tags, use "unknown"
+        if [ -z "$gdal_ver" ]; then
+            gdal_ver="unknown"
+        fi
+
+        # Store version details
+        version_details["$version_id"]="$created_at|$tags"
+
+        # Track latest creation time for each GDAL version
+        if [ -z "${gdal_versions[$gdal_ver]}" ] || [ "$created_at" \> "${gdal_versions[$gdal_ver]}" ]; then
+            gdal_versions[$gdal_ver]="$created_at"
+        fi
+    done <<< "$(echo "$all_versions" | jq -c '.')"
+
+    # Sort GDAL versions by creation time (newest first) and keep top N
+    sorted_gdal_versions=$(for ver in "${!gdal_versions[@]}"; do
+        echo "${gdal_versions[$ver]}|$ver"
+    done | sort -r | head -n "$KEEP_VERSIONS" | cut -d'|' -f2)
+
+    # Build lists of versions to keep and remove
+    keep_versions=()
+    remove_versions=()
+
+    for version_id in "${!version_details[@]}"; do
+        details="${version_details[$version_id]}"
+        created_at=$(echo "$details" | cut -d'|' -f1)
+
+        # Extract GDAL version for this version
+        gdal_ver=""
+        tags=$(echo "$details" | cut -d'|' -f2-)
+        for tag in $tags; do
+            if [[ $tag =~ gdal-([0-9]+\.[0-9]+) ]]; then
+                gdal_ver="${BASH_REMATCH[1]}"
+                break
+            elif [[ $tag =~ deps-gdal-([0-9]+\.[0-9]+) ]]; then
+                gdal_ver="${BASH_REMATCH[1]}"
+                break
+            fi
+        done
+        if [ -z "$gdal_ver" ]; then
+            gdal_ver="unknown"
+        fi
+
+        # Check if this GDAL version should be kept
+        should_keep=false
+        for keep_gdal_ver in $sorted_gdal_versions; do
+            if [ "$gdal_ver" = "$keep_gdal_ver" ]; then
+                should_keep=true
+                break
+            fi
+        done
+
+        if [ "$should_keep" = true ]; then
+            keep_versions+=("$version_id")
+        else
+            remove_versions+=("$version_id")
+        fi
+    done
+
+    keep_count=${#keep_versions[@]}
+    remove_count=${#remove_versions[@]}
+
+    echo "  Found ${#version_details[@]} versions across ${#gdal_versions[@]} GDAL versions"
+    echo "  Keeping $KEEP_VERSIONS most recent GDAL versions ($keep_count images)"
+    echo "  Would remove $remove_count older images from older GDAL versions"
+
+    # Show GDAL versions to keep
+    if [ ${#sorted_gdal_versions[@]} -gt 0 ]; then
+        echo "  [PIN] GDAL versions to keep:"
+        for gdal_ver in $sorted_gdal_versions; do
+            echo "    [OK] GDAL $gdal_ver"
+        done
+    fi
+
+    # Show versions to keep with details
+    if [ $keep_count -gt 0 ]; then
+        echo "  [PKG] Images to keep:"
+        for version_id in "${keep_versions[@]}"; do
+            details="${version_details[$version_id]}"
+            created_at=$(echo "$details" | cut -d'|' -f1)
+            tags=$(echo "$details" | cut -d'|' -f2-)
+            tag_list=$(echo "$tags" | tr '\n' ',' | sed 's/,$//')
+            [ -z "$tag_list" ] && tag_list="untagged"
+            echo "    [OK] $tag_list (created: $created_at)"
+        done
+    fi
+
+    # Show versions to remove
+    if [ $remove_count -gt 0 ]; then
+        echo "  [REMOVE]  Images to remove:"
+        for version_id in "${remove_versions[@]}"; do
+            details="${version_details[$version_id]}"
+            created_at=$(echo "$details" | cut -d'|' -f1)
+            tags=$(echo "$details" | cut -d'|' -f2-)
+            tag_list=$(echo "$tags" | tr '\n' ',' | sed 's/,$//')
+            [ -z "$tag_list" ] && tag_list="untagged"
+            echo "    [FAIL] $tag_list (created: $created_at)"
+        done
+
+        # Confirm removal unless forced or dry run
+        if [ "$DRY_RUN" = false ] && [ "$FORCE" = false ]; then
+            echo
+            read -p "  Remove these $remove_count old images from older GDAL versions? (y/N): " -n 1 -r
+            echo
+            if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+                echo "  [SKIP]  Skipping removal for $package"
+                continue
+            fi
+        fi
+
+        # Perform removal
+        if [ "$DRY_RUN" = false ]; then
+            echo "  [ACTION] Removing old versions..."
+            removed=0
+            for version_id in $remove_versions; do
+                if gh api -X DELETE "/user/packages/container/$package/versions/$version_id" 2>/dev/null; then
+                    echo "    [OK] Successfully removed version $version_id"
+                    ((removed++))
+                    ((total_removed++))
+                else
+                    echo "    [FAIL] Failed to remove version $version_id"
+                fi
+            done
+            echo "  [DONE] Removed $removed out of $remove_count images from older GDAL versions"
+        else
+            echo "  [SKIP]  Skipping removal (dry run)"
+        fi
+    else
+        echo "  [OK] No old versions to remove"
+    fi
+
+    echo
+done <<< "$packages"
+
+# Summary
+echo "[SUMMARY] Cleanup Summary:"
+if [ "$DRY_RUN" = true ]; then
+    echo "  - Analyzed all packages"
+    echo "  - No images were actually removed (dry run)"
+    echo "  - Review the output above to see what would be cleaned up"
+else
+    echo "  - Analyzed all packages"
+    echo "  - Successfully removed $total_removed old image versions"
+    echo "  - Kept the $KEEP_VERSIONS most recent GDAL versions and all their associated images"
+fi

--- a/scripts/cleanup-local-docker-images.sh
+++ b/scripts/cleanup-local-docker-images.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+
+# cleanup-local-docker-images.sh
+# Local Docker cleanup script for gdalcli Docker images
+# Removes old local Docker images you've pulled, keeps the most recent base and runtime images
+# Supports dry-run and force modes for safety
+
+set -e
+
+DRY_RUN=false
+FORCE=false
+REPO="ghcr.io/brownag/gdalcli"
+
+usage() {
+    echo "Usage: $0 [--dry-run] [--force] [--repo REPO]"
+    echo "  --dry-run: Show what would be removed without actually removing"
+    echo "  --force: Skip confirmation prompts"
+    echo "  --repo REPO: Docker repository to clean (default: $REPO)"
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --force)
+            FORCE=true
+            shift
+            ;;
+        --repo)
+            REPO="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            ;;
+    esac
+done
+
+# Get all images for the repository
+echo "Fetching Docker images for $REPO..."
+images=$(docker images "$REPO" --format "{{.Repository}}:{{.Tag}}" 2>/dev/null || echo "")
+
+if [ -z "$images" ]; then
+    echo "No images found for $REPO"
+    exit 0
+fi
+
+echo "Found images:"
+echo "$images" | sort
+echo
+
+# Function to extract and find the maximum version for a given pattern
+get_max_version() {
+    local pattern="$1"
+    local versions=()
+
+    for img in $images; do
+        tag="${img#*:}"
+        if [[ $tag =~ $pattern ]]; then
+            ver="${BASH_REMATCH[1]}"
+            versions+=("$ver")
+        fi
+    done
+
+    if [ ${#versions[@]} -eq 0 ]; then
+        echo ""
+        return
+    fi
+
+    # Sort versions numerically and get the latest
+    printf '%s\n' "${versions[@]}" | sort -V | tail -1
+}
+
+# Patterns for different image types (matching your actual naming scheme)
+deps_pattern='deps-gdal-(.+)-amd64'
+runtime_pattern='gdal-(.+)-latest'
+
+# Find the latest versions
+deps_max=$(get_max_version "$deps_pattern")
+runtime_max=$(get_max_version "$runtime_pattern")
+
+echo "Latest versions found:"
+[ -n "$deps_max" ] && echo "  Deps: $deps_max"
+[ -n "$runtime_max" ] && echo "  Runtime: $runtime_max"
+echo
+
+# Build list of images to keep
+keep_images=()
+if [ -n "$deps_max" ]; then
+    keep_images+=("$REPO:deps-gdal-${deps_max}-amd64")
+fi
+if [ -n "$runtime_max" ]; then
+    keep_images+=("$REPO:gdal-${runtime_max}-latest")
+fi
+
+# Build list of images to remove (matching patterns but not in keep list)
+remove_images=()
+for img in $images; do
+    tag="${img#*:}"
+    if [[ $tag =~ $deps_pattern ]] || [[ $tag =~ $runtime_pattern ]]; then
+        keep=false
+        for keep_img in "${keep_images[@]}"; do
+            if [ "$img" = "$keep_img" ]; then
+                keep=true
+                break
+            fi
+        done
+        if [ "$keep" = false ]; then
+            remove_images+=("$img")
+        fi
+    fi
+done
+
+# Dry run mode
+if [ "$DRY_RUN" = true ]; then
+    echo "DRY RUN MODE - No images will be removed"
+    echo
+    echo "Images to keep (${#keep_images[@]}):"
+    for img in "${keep_images[@]}"; do
+        echo "  [OK] $img"
+    done
+    echo
+    echo "Images to remove (${#remove_images[@]}):"
+    for img in "${remove_images[@]}"; do
+        echo "  [FAIL] $img"
+    done
+    echo
+    echo "Dry run complete."
+    exit 0
+fi
+
+# Check if there are images to remove
+if [ ${#remove_images[@]} -eq 0 ]; then
+    echo "No old images to remove. All images are up to date."
+    exit 0
+fi
+
+# Show what will be removed
+echo "Images to keep (${#keep_images[@]}):"
+for img in "${keep_images[@]}"; do
+    echo "  [OK] $img"
+done
+echo
+echo "Images to remove (${#remove_images[@]}):"
+for img in "${remove_images[@]}"; do
+    echo "  [FAIL] $img"
+done
+echo
+
+# Safety check unless forced
+if [ "$FORCE" = false ]; then
+    read -p "Do you want to proceed with removing these images? (y/N): " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "Operation cancelled."
+        exit 0
+    fi
+fi
+
+# Remove images
+echo "Removing images..."
+removed_count=0
+for img in "${remove_images[@]}"; do
+    echo "Removing $img..."
+    if docker rmi "$img" 2>/dev/null; then
+        echo "  [OK] Successfully removed $img"
+        ((removed_count++))
+    else
+        echo "  [FAIL] Failed to remove $img (may not exist or be in use)"
+    fi
+done
+
+echo
+echo "Cleanup complete. Successfully removed $removed_count out of ${#remove_images[@]} images."
+
+# Optional: Run system prune to clean up any remaining artifacts
+if [ "$FORCE" = true ] || [ "$DRY_RUN" = false ]; then
+    echo "Running docker system prune to clean up remaining artifacts..."
+    docker system prune -f >/dev/null 2>&1
+    echo "System cleanup complete."
+fi


### PR DESCRIPTION
This pull request introduces automated cleanup processes for Docker images, both locally and in the GitHub Container Registry (GHCR), to help manage disk usage and keep only the most recent images. It adds scripts for local and remote cleanup, a new GitHub Actions workflow for GHCR cleanup, and updates the documentation to explain these maintenance tools.

* Added `scripts/cleanup-local-docker-images.sh`, a script to clean up old local Docker images, keeping only the latest base and runtime images. Supports dry-run and force options for safety.
* Added `scripts/cleanup-ghcr-images.sh`, a script for removing older images from GHCR using the GitHub CLI, with options for dry-run, force, and controlling the number of versions to keep.
* Added `.github/workflows/cleanup-ghcr.yml`, a GitHub Actions workflow to automate GHCR image cleanup, supporting manual triggers and configurable options for safe deletion.
* Expanded `CONTRIBUTING.md` with a new section on Docker image maintenance, detailing how to use the cleanup scripts and workflow, their options, and the retention policy for images.