### PR TITLE
fix(ci): cleanup workspace.Rcheck to avoid issues with stash step

### DIFF
--- a/.github/workflows/build-releases.yml
+++ b/.github/workflows/build-releases.yml
@@ -245,6 +245,10 @@ jobs:
 
           BRANCH="${{ needs.validate.outputs.branch_name }}"
           
+          # Clean up R check directory with restricted permissions before stashing
+          echo "Cleaning up build artifacts..."
+          sudo rm -rf workspace.Rcheck 2>/dev/null || rm -rf workspace.Rcheck
+          
           # Stash any uncommitted changes (including untracked generated files)
           echo "Stashing generated files and changes..."
           git stash push -u -m "temp: generated files for $BRANCH"


### PR DESCRIPTION
This pull request adds a cleanup step to the build process in the GitHub Actions workflow to ensure build artifacts are removed before stashing changes. This helps prevent permission issues and ensures a clean workspace for subsequent steps.